### PR TITLE
Fixed icons export

### DIFF
--- a/src/components/icon/icons/index.ts
+++ b/src/components/icon/icons/index.ts
@@ -1,2 +1,4 @@
-export { default as plus } from './plus.svg'
-export { default as minus } from './minus.svg'
+import { default as plus } from './plus.svg'
+import { default as minus } from './minus.svg'
+
+export { plus, minus }


### PR DESCRIPTION
Fixes `TypeError: Cannot read property 'viewBox' of undefined` after `run dev`